### PR TITLE
Compact UI overhaul: flatter cards, sticky header, tighter sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ dist-ssr
 
 # Data pipeline — user-provided ESPN input files
 data/cache/espn-input.*
+screenshots/

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=PT+Sans+Narrow:wght@400;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <title>fantasy football grid</title>
     <meta name="description" content="Fantasy football draft assistant — visual grid with position colors, keeper tracking, and live draft board for 2026." />
   </head>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=PT+Sans+Narrow:wght@400;700&display=swap" rel="stylesheet" />
     <title>fantasy football grid</title>
     <meta name="description" content="Fantasy football draft assistant — visual grid with position colors, keeper tracking, and live draft board for 2026." />
   </head>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <title>fantasy football grid</title>
     <meta name="description" content="Fantasy football draft assistant — visual grid with position colors, keeper tracking, and live draft board for 2026." />
   </head>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..700&display=swap" rel="stylesheet" />
     <title>fantasy football grid</title>
     <meta name="description" content="Fantasy football draft assistant — visual grid with position colors, keeper tracking, and live draft board for 2026." />
   </head>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -361,7 +361,7 @@ const clearDraft = () => {
     text-align: center;
     line-height: 1.15;
     align-self: center;
-    letter-spacing: -0.02em;
+    letter-spacing: -0.04em;
     word-break: break-word;
   }
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -334,7 +334,6 @@ const undoClear = (which: 'keepers' | 'draft') => {
     background: transparent;
     position: relative;
     aspect-ratio: 1;
-    max-width: 72px;
     transition: filter 0.15s, box-shadow 0.15s;
     font-family: 'Barlow Condensed', 'Inter', system-ui, sans-serif;
   }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -91,7 +91,7 @@ const clearDraft = () => {
     </div>
   </header>
   <main>
-    <div class="grid">
+    <div class="grid" class:grid-readonly={$currentTab === "all players"}>
       {#each $currentPlayerSet as round}
         {#each round as player (player.rank)}
           <button
@@ -321,6 +321,15 @@ const clearDraft = () => {
     outline: 2px solid #fff;
     outline-offset: 2px;
     z-index: 3;
+  }
+
+  .grid-readonly .player {
+    cursor: default;
+  }
+
+  .grid-readonly .player:hover {
+    filter: none;
+    box-shadow: none;
   }
 
   .player-meta {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -310,7 +310,7 @@ const clearDraft = () => {
     aspect-ratio: 1;
     overflow: hidden;
     transition: filter 0.15s, box-shadow 0.15s;
-    font-family: 'Barlow Condensed', 'Inter', system-ui, sans-serif;
+    font-family: 'PT Sans Narrow', 'Inter', system-ui, sans-serif;
   }
 
   .player:nth-child(12n) {
@@ -335,7 +335,7 @@ const clearDraft = () => {
     gap: clamp(0.1rem, 0.5vw, 0.3rem);
     align-items: center;
     font-size: clamp(0.45rem, 1.8vw, 0.65rem);
-    font-weight: 600;
+    font-weight: 700;
     line-height: 1.2;
     white-space: nowrap;
   }
@@ -355,7 +355,7 @@ const clearDraft = () => {
 
   .player-name {
     grid-area: name;
-    font-weight: 600;
+    font-weight: 700;
     font-size: calc(clamp(0.48rem, 1vw, 0.8rem) * var(--name-scale, 1));
     text-align: center;
     line-height: 1.15;

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -278,6 +278,7 @@ const clearDraft = () => {
   main {
     display: flex;
     justify-content: space-between;
+    overflow: hidden;
   }
 
   /* ---- grid ---- */
@@ -288,6 +289,7 @@ const clearDraft = () => {
     gap: 2px;
     place-items: stretch;
     flex: 1;
+    min-width: 0;
   }
 
   /* ---- player card ---- */

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -113,7 +113,7 @@ const clearDraft = () => {
               <span class="player-pos">{player.position.position}</span>
               <span class="player-team">{player.team}</span>
             </span>
-            <span class="player-name" style="--name-scale: {Math.max(0.80, 1 - (player.name.length - 12) * 0.025)}">{player.name}</span>
+            <span class="player-name" style="--name-scale: {Math.max(0.82, 1 - (Math.max(...player.name.split(' ').map(w => w.length)) - 7) * 0.035)}">{player.name}</span>
             <span class="player-ranks">
               {#if player.rankings}
                 <span>FF {player.rankings.ff ?? '—'}</span>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -355,7 +355,7 @@ const clearDraft = () => {
   .player-name {
     grid-area: name;
     font-weight: 600;
-    font-size: clamp(0.45rem, 1.1vw, 0.8rem);
+    font-size: clamp(0.48rem, 1.1vw, 0.85rem);
     text-align: center;
     line-height: 1.15;
     align-self: center;
@@ -545,7 +545,7 @@ const clearDraft = () => {
 
   @media (min-width: 1100px) {
     .player-name {
-      font-size: clamp(0.8rem, 1.8vw, 1.25rem);
+      font-size: clamp(0.85rem, 1.9vw, 1.35rem);
     }
   }
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -355,7 +355,7 @@ const clearDraft = () => {
   .player-name {
     grid-area: name;
     font-weight: 600;
-    font-size: clamp(0.5rem, 1.2vw, 0.9rem);
+    font-size: clamp(0.45rem, 1.1vw, 0.8rem);
     text-align: center;
     line-height: 1.15;
     align-self: center;
@@ -545,7 +545,7 @@ const clearDraft = () => {
 
   @media (min-width: 1100px) {
     .player-name {
-      font-size: clamp(0.9rem, 2vw, 1.4rem);
+      font-size: clamp(0.8rem, 1.8vw, 1.25rem);
     }
   }
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -355,7 +355,7 @@ const clearDraft = () => {
   .player-name {
     grid-area: name;
     font-weight: 600;
-    font-size: clamp(0.55rem, 3vw, 0.85rem);
+    font-size: clamp(0.55rem, 6vw, 2rem);
     text-align: center;
     line-height: 1.15;
     align-self: center;

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -113,7 +113,7 @@ const clearDraft = () => {
               <span class="player-pos">{player.position.position}</span>
               <span class="player-team">{player.team}</span>
             </span>
-            <span class="player-name" style="--name-scale: {Math.max(0.78, 1 - (Math.max(...player.name.split(' ').map(w => w.length)) - 7) * 0.045)}">{player.name}</span>
+            <span class="player-name" style="--name-scale: {Math.max(0.75, 1 - (Math.max(...player.name.split(' ').map(w => w.length)) - 7) * 0.055)}">{player.name}</span>
             <span class="player-ranks">
               {#if player.rankings}
                 <span>FF {player.rankings.ff ?? '—'}</span>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -298,6 +298,7 @@ const clearDraft = () => {
     color: #fff;
     appearance: none;
     display: grid;
+    grid-template-columns: minmax(0, 1fr);
     grid-template-rows: auto 1fr auto;
     grid-template-areas:
       "meta"
@@ -339,6 +340,7 @@ const clearDraft = () => {
     font-weight: 600;
     line-height: 1.2;
     white-space: nowrap;
+    overflow: hidden;
   }
 
   .player-rank {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -310,7 +310,6 @@ const clearDraft = () => {
     aspect-ratio: 1;
     overflow: hidden;
     transition: filter 0.15s, box-shadow 0.15s;
-    font-family: 'PT Sans Narrow', 'Inter', system-ui, sans-serif;
   }
 
   .player:nth-child(12n) {
@@ -335,7 +334,7 @@ const clearDraft = () => {
     gap: clamp(0.1rem, 0.5vw, 0.3rem);
     align-items: center;
     font-size: clamp(0.45rem, 1.8vw, 0.65rem);
-    font-weight: 700;
+    font-weight: 600;
     line-height: 1.2;
     white-space: nowrap;
   }
@@ -355,7 +354,7 @@ const clearDraft = () => {
 
   .player-name {
     grid-area: name;
-    font-weight: 700;
+    font-weight: 600;
     font-size: calc(clamp(0.48rem, 1vw, 0.8rem) * var(--name-scale, 1));
     text-align: center;
     line-height: 1.15;

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -15,7 +15,7 @@ import players, { type Player } from './players';
 // biome-ignore lint/correctness/noUnusedVariables: used in template {#await ready}
 let { keepers, currentTab, draft, ready } = stores;
 
-const playersList = (isDraft: boolean, drafted: Player[], keepers: Player[], players: Player[]) => {
+const playersList = (isDraft: boolean, drafted: Player[], keepers: Player[]) => {
   if (!isDraft) {
     return players;
   }
@@ -26,14 +26,10 @@ const playersList = (isDraft: boolean, drafted: Player[], keepers: Player[], pla
   ];
 };
 
-// Derived store for currentPlayerSet
 const currentPlayerSet = derived(
   [keepers, currentTab, draft],
-  (d) => {
-    // Return the chunked player list
-    return chunkedPlayers(playersList($currentTab === 'draft', $draft, $keepers, players));
-  },
-  [], // Initial value for currentPlayerSet
+  () => chunkedPlayers(playersList($currentTab === 'draft', $draft, $keepers)),
+  [],
 );
 
 const onClick = (player: Player) => () => {
@@ -49,33 +45,13 @@ const onClick = (player: Player) => () => {
 const clearKeepers = () => {
   if (!$keepers.length) return;
   if (!confirm(`Clear all Keepers? (This will delete ${$keepers.length})`)) return;
-  // Backup for one-shot undo
-  try {
-    sessionStorage.setItem('keepers-backup', JSON.stringify($keepers));
-  } catch {}
   $keepers = [];
 };
 
 const clearDraft = () => {
   if (!$draft.length) return;
   if (!confirm(`Clear all Drafted Players? (This will delete ${$draft.length})`)) return;
-  try {
-    sessionStorage.setItem('draft-backup', JSON.stringify($draft));
-  } catch {}
   $draft = [];
-};
-
-const undoClear = (which: 'keepers' | 'draft') => {
-  const key = `${which}-backup`;
-  try {
-    const backup = sessionStorage.getItem(key);
-    if (backup) {
-      const data = JSON.parse(backup);
-      if (which === 'keepers') $keepers = data;
-      else $draft = data;
-      sessionStorage.removeItem(key);
-    }
-  } catch {}
 };
 </script>
 
@@ -130,7 +106,7 @@ const undoClear = (which: 'keepers' | 'draft') => {
             class:player-drafted={findPlayer(player, $draft)}
             disabled={$currentTab === "keepers" &&
               findPlayer(player, $draft) !== undefined}
-            title="{player.name} - Variance: {player.variance || 0}{player.rankings ? ` | FF: ${player.rankings.ff || 'N/A'} | ESPN: ${player.rankings.espn || 'N/A'} | FP: ${player.rankings.fp || 'N/A'}` : ''}"
+            title="{player.name} — Variance: {player.variance || 0}"
           >
             <span class="player-meta">
               <span class="player-rank">#{player.rank}</span>
@@ -172,9 +148,7 @@ const undoClear = (which: 'keepers' | 'draft') => {
           </div>
         {/if}
         {#if $currentTab === "draft"}
-          <div class="tab-header">
-            <h2>Draft <span class="draft-info">R{currentRound($draft)} · P{currentPick($draft)}</span></h2>
-          </div>
+          <h2>Draft <span class="draft-info">R{currentRound($draft)} · P{currentPick($draft)}</span></h2>
 
           <div class="draft">
             {#each $draft as player, idx}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -114,13 +114,6 @@ const clearDraft = () => {
               <span class="player-team">{player.team}</span>
             </span>
             <span class="player-name" style="--name-scale: {Math.max(0.75, 1 - (Math.max(...player.name.split(' ').map(w => w.length)) - 7) * 0.055)}">{player.name}</span>
-            <span class="player-ranks">
-              {#if player.rankings}
-                <span>FF {player.rankings.ff ?? '—'}</span>
-                <span>ESPN {player.rankings.espn ?? '—'}</span>
-                <span>FP {player.rankings.fp ?? '—'}</span>
-              {/if}
-            </span>
           </button>
         {/each}
       {/each}
@@ -299,11 +292,10 @@ const clearDraft = () => {
     appearance: none;
     display: grid;
     grid-template-columns: minmax(0, 1fr);
-    grid-template-rows: auto 1fr auto;
+    grid-template-rows: auto 1fr;
     grid-template-areas:
       "meta"
-      "name"
-      "ranks";
+      "name";
     border: 1px solid rgba(255,255,255,0.08);
     margin: 0;
     padding: clamp(1px, 0.3vw, 4px) clamp(2px, 0.5vw, 5px);
@@ -367,21 +359,6 @@ const clearDraft = () => {
     align-self: center;
     letter-spacing: -0.04em;
     word-break: break-word;
-  }
-
-  .player-ranks {
-    grid-area: ranks;
-    display: flex;
-    justify-content: space-around;
-    font-size: clamp(0.35rem, 1.4vw, 0.52rem);
-    font-weight: 400;
-    opacity: 0.6;
-    line-height: 1;
-    padding-top: 1px;
-  }
-
-  .player-ranks span {
-    white-space: nowrap;
   }
 
   /* ---- selected states ---- */
@@ -537,17 +514,6 @@ const clearDraft = () => {
       font-stretch: normal;
       letter-spacing: normal;
       font-size: clamp(0.5rem, 2.5vw, 0.7rem);
-    }
-
-    .player-ranks {
-      display: none;
-    }
-
-    .player {
-      grid-template-rows: auto 1fr;
-      grid-template-areas:
-        "meta"
-        "name";
     }
 
     [role="tablist"] button {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -357,7 +357,7 @@ const clearDraft = () => {
     font-weight: 600;
     font-stretch: condensed;
     font-feature-settings: "ss02", "cv12", "cv13";
-    font-size: calc(clamp(0.48rem, 1vw, 0.8rem) * var(--name-scale, 1));
+    font-size: calc(clamp(0.45rem, 0.95vw, 0.76rem) * var(--name-scale, 1));
     text-align: center;
     line-height: 1.15;
     align-self: center;
@@ -539,7 +539,7 @@ const clearDraft = () => {
 
   @media (min-width: 1100px) {
     .player-name {
-      font-size: calc(clamp(0.8rem, 1.6vw, 1.2rem) * var(--name-scale, 1));
+      font-size: calc(clamp(0.76rem, 1.5vw, 1.15rem) * var(--name-scale, 1));
     }
   }
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -355,7 +355,7 @@ const clearDraft = () => {
   .player-name {
     grid-area: name;
     font-weight: 600;
-    font-size: clamp(0.55rem, 6vw, 2rem);
+    font-size: clamp(0.55rem, 2.2vw, 2rem);
     text-align: center;
     line-height: 1.15;
     align-self: center;

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -113,7 +113,7 @@ const clearDraft = () => {
               <span class="player-pos">{player.position.position}</span>
               <span class="player-team">{player.team}</span>
             </span>
-            <span class="player-name" style="--name-scale: {Math.max(0.82, 1 - (player.name.length - 12) * 0.018)}">{player.name}</span>
+            <span class="player-name" style="--name-scale: {Math.max(0.82, 1 - (player.name.length - 12) * 0.02)}">{player.name}</span>
             <span class="player-ranks">
               {#if player.rankings}
                 <span>FF {player.rankings.ff ?? '—'}</span>
@@ -363,6 +363,7 @@ const clearDraft = () => {
     align-self: center;
     letter-spacing: -0.04em;
     word-break: break-word;
+    hyphens: auto;
   }
 
   .player-ranks {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -113,7 +113,7 @@ const clearDraft = () => {
               <span class="player-pos">{player.position.position}</span>
               <span class="player-team">{player.team}</span>
             </span>
-            <span class="player-name" style="--name-scale: {player.name.length > 17 ? 0.78 : player.name.length > 14 ? 0.88 : 1}">{player.name}</span>
+            <span class="player-name" style="--name-scale: {player.name.length > 15 ? 0.72 : player.name.length > 12 ? 0.85 : 1}">{player.name}</span>
             <span class="player-ranks">
               {#if player.rankings}
                 <span>FF {player.rankings.ff ?? '—'}</span>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -138,11 +138,18 @@ const undoClear = (which: 'keepers' | 'draft') => {
               <span class="player-team">{player.team}</span>
             </span>
             <span class="player-name">{player.name}</span>
+            <span class="player-ranks">
+              {#if player.rankings}
+                <span>FF {player.rankings.ff ?? '—'}</span>
+                <span>ESPN {player.rankings.espn ?? '—'}</span>
+                <span>FP {player.rankings.fp ?? '—'}</span>
+              {/if}
+            </span>
             <span class="compass-container">
               <RankingArrow 
                 vector={player.vector} 
                 consensusStrength={player.consensusStrength}
-                size={22}
+                size={30}
               />
             </span>
           </button>
@@ -311,7 +318,7 @@ const undoClear = (which: 'keepers' | 'draft') => {
     margin: 0.5rem;
     display: grid;
     grid-template-columns: repeat(12, 1fr);
-    gap: 1px;
+    gap: 2px;
     place-items: stretch;
     flex: 1;
   }
@@ -323,18 +330,24 @@ const undoClear = (which: 'keepers' | 'draft') => {
     appearance: none;
     display: grid;
     grid-template-columns: 1fr auto;
-    grid-template-rows: auto 1fr;
+    grid-template-rows: auto 1fr auto;
     grid-template-areas:
       "meta compass"
-      "name compass";
+      "name compass"
+      "ranks compass";
     border: 1px solid rgba(255,255,255,0.08);
     margin: 0;
-    padding: 2px 4px;
+    padding: 3px 5px;
     cursor: pointer;
     background: transparent;
     position: relative;
     aspect-ratio: 1;
     transition: filter 0.15s, box-shadow 0.15s;
+    font-family: 'Barlow Condensed', 'Inter', system-ui, sans-serif;
+  }
+
+  .player:nth-child(12n) {
+    border-bottom: 1px solid rgba(255,255,255,0.2);
   }
 
   .player:hover {
@@ -354,7 +367,7 @@ const undoClear = (which: 'keepers' | 'draft') => {
     display: flex;
     gap: 0.3rem;
     align-items: center;
-    font-size: 0.6rem;
+    font-size: 0.65rem;
     font-weight: 600;
     line-height: 1.2;
     white-space: nowrap;
@@ -375,20 +388,36 @@ const undoClear = (which: 'keepers' | 'draft') => {
 
   .player-name {
     grid-area: name;
-    font-weight: 500;
-    font-size: 0.75rem;
-    text-align: left;
+    font-weight: 600;
+    font-size: 0.85rem;
+    text-align: center;
     line-height: 1.15;
     align-self: center;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    letter-spacing: 0.01em;
+  }
+
+  .player-ranks {
+    grid-area: ranks;
+    display: flex;
+    justify-content: space-around;
+    font-size: 0.52rem;
+    font-weight: 400;
+    opacity: 0.6;
+    line-height: 1;
+    padding-top: 1px;
+  }
+
+  .player-ranks span {
+    white-space: nowrap;
   }
 
   .compass-container {
     grid-area: compass;
-    width: 22px;
-    height: 22px;
+    width: 30px;
+    height: 30px;
     align-self: start;
     justify-self: end;
     position: relative;
@@ -510,7 +539,7 @@ const undoClear = (which: 'keepers' | 'draft') => {
     }
 
     .player-name {
-      font-size: 0.6rem;
+      font-size: 0.65rem;
     }
 
     .player-meta {
@@ -518,9 +547,13 @@ const undoClear = (which: 'keepers' | 'draft') => {
       gap: 0.15rem;
     }
 
+    .player-ranks {
+      font-size: 0.44rem;
+    }
+
     .compass-container {
-      width: 16px;
-      height: 16px;
+      width: 20px;
+      height: 20px;
     }
 
     [role="tablist"] button {
@@ -573,7 +606,7 @@ const undoClear = (which: 'keepers' | 'draft') => {
     }
 
     .player-name {
-      font-size: 0.52rem;
+      font-size: 0.55rem;
     }
 
     .player-meta {
@@ -581,9 +614,13 @@ const undoClear = (which: 'keepers' | 'draft') => {
       gap: 0.1rem;
     }
 
+    .player-ranks {
+      font-size: 0.38rem;
+    }
+
     .compass-container {
-      width: 12px;
-      height: 12px;
+      width: 14px;
+      height: 14px;
     }
 
     .grid {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -394,9 +394,11 @@ const undoClear = (which: 'keepers' | 'draft') => {
     line-height: 1.15;
     align-self: center;
     overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
     letter-spacing: 0.01em;
+    word-break: break-word;
   }
 
   .player-ranks {
@@ -508,9 +510,11 @@ const undoClear = (which: 'keepers' | 'draft') => {
     line-height: 1.2;
     flex: 1;
     min-width: 0;
-    white-space: nowrap;
     overflow: hidden;
-    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    word-break: break-word;
   }
 
   aside .draft-player .rank {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -232,23 +232,23 @@ const undoClear = (which: 'keepers' | 'draft') => {
   [role="tablist"] button {
     border: 0;
     background: transparent;
-    color: #aaa;
-    padding: 0.35rem 0.75rem;
-    font-size: 0.8rem;
+    color: #888;
+    padding: 0.3rem 0.75rem;
+    font-size: 0.78rem;
     cursor: pointer;
     font-weight: 500;
-    text-transform: lowercase;
-    transition: color 0.15s, background 0.15s;
-    border-radius: 3px 3px 0 0;
+    transition: color 0.15s, box-shadow 0.15s;
+    border-radius: 4px;
+    margin-right: 2px;
   }
 
   [role="tablist"] button:hover {
-    color: #fff;
+    color: #ccc;
   }
 
   [role="tablist"] button.selected {
-    background: #444;
     color: #fff;
+    box-shadow: inset 0 -2px 0 #fff;
   }
 
   .header-right {
@@ -260,23 +260,24 @@ const undoClear = (which: 'keepers' | 'draft') => {
   .legend-toggle {
     background: none;
     border: 1px solid #555;
-    color: #aaa;
-    width: 22px;
-    height: 22px;
+    color: #999;
+    width: 20px;
+    height: 20px;
     border-radius: 50%;
-    font-size: 0.7rem;
-    font-weight: 700;
+    font-size: 0.65rem;
+    font-weight: 500;
     cursor: pointer;
     display: flex;
     align-items: center;
     justify-content: center;
     padding: 0;
+    line-height: 1;
     transition: color 0.15s, border-color 0.15s;
   }
 
   .legend-toggle:hover {
     color: #fff;
-    border-color: #888;
+    border-color: #999;
   }
 
   nav {
@@ -284,23 +285,19 @@ const undoClear = (which: 'keepers' | 'draft') => {
   }
 
   nav button {
-    border: 0;
-    font-size: 0.75rem;
+    border: 1px solid #444;
+    border-radius: 4px;
+    font-size: 0.72rem;
     background: transparent;
-    border-top: 2px solid #444;
-    border-left: 2px solid #444;
-    padding: 0.35rem 0.6rem;
+    padding: 0.3rem 0.6rem;
     cursor: pointer;
-    color: #aaa;
-    transition: color 0.15s;
-  }
-
-  nav button:last-child {
-    border-right: 2px solid #444;
+    color: #999;
+    transition: color 0.15s, border-color 0.15s;
   }
 
   nav button:hover:not(:disabled) {
     color: #fff;
+    border-color: #777;
   }
 
   /* ---- main layout ---- */

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -355,11 +355,13 @@ const clearDraft = () => {
   .player-name {
     grid-area: name;
     font-weight: 600;
+    font-stretch: condensed;
+    font-feature-settings: "ss02", "cv12", "cv13";
     font-size: calc(clamp(0.48rem, 1vw, 0.8rem) * var(--name-scale, 1));
     text-align: center;
     line-height: 1.15;
     align-self: center;
-    letter-spacing: 0.01em;
+    letter-spacing: -0.02em;
     word-break: break-word;
   }
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -535,6 +535,23 @@ const clearDraft = () => {
     .grid {
       margin: 0.25rem;
     }
+
+    .player-name {
+      font-stretch: normal;
+      letter-spacing: normal;
+      font-size: clamp(0.5rem, 2.5vw, 0.7rem);
+    }
+
+    .player-ranks {
+      display: none;
+    }
+
+    .player {
+      grid-template-rows: auto 1fr;
+      grid-template-areas:
+        "meta"
+        "name";
+    }
   }
 
   @media (min-width: 1100px) {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -113,7 +113,7 @@ const clearDraft = () => {
               <span class="player-pos">{player.position.position}</span>
               <span class="player-team">{player.team}</span>
             </span>
-            <span class="player-name" style="--name-scale: {Math.max(0.82, 1 - (player.name.length - 12) * 0.02)}">{player.name}</span>
+            <span class="player-name" style="--name-scale: {Math.max(0.80, 1 - (player.name.length - 12) * 0.025)}">{player.name}</span>
             <span class="player-ranks">
               {#if player.rankings}
                 <span>FF {player.rankings.ff ?? '—'}</span>
@@ -363,7 +363,6 @@ const clearDraft = () => {
     align-self: center;
     letter-spacing: -0.04em;
     word-break: break-word;
-    hyphens: auto;
   }
 
   .player-ranks {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -113,7 +113,7 @@ const clearDraft = () => {
               <span class="player-pos">{player.position.position}</span>
               <span class="player-team">{player.team}</span>
             </span>
-            <span class="player-name">{player.name}</span>
+            <span class="player-name" style="--name-scale: {player.name.length > 17 ? 0.78 : player.name.length > 14 ? 0.88 : 1}">{player.name}</span>
             <span class="player-ranks">
               {#if player.rankings}
                 <span>FF {player.rankings.ff ?? '—'}</span>
@@ -356,7 +356,7 @@ const clearDraft = () => {
   .player-name {
     grid-area: name;
     font-weight: 600;
-    font-size: clamp(0.48rem, 1vw, 0.8rem);
+    font-size: calc(clamp(0.48rem, 1vw, 0.8rem) * var(--name-scale, 1));
     text-align: center;
     line-height: 1.15;
     align-self: center;
@@ -538,7 +538,7 @@ const clearDraft = () => {
 
   @media (min-width: 1100px) {
     .player-name {
-      font-size: clamp(0.8rem, 1.6vw, 1.2rem);
+      font-size: calc(clamp(0.8rem, 1.6vw, 1.2rem) * var(--name-scale, 1));
     }
   }
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -312,9 +312,9 @@ const clearDraft = () => {
   }
 
   .player:hover {
-    filter: brightness(1.2);
+    filter: brightness(1.08);
     z-index: 2;
-    box-shadow: 0 0 0 2px rgba(255,255,255,0.25);
+    box-shadow: 0 0 0 2px rgba(255,255,255,0.12);
   }
 
   .player:focus-visible {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -355,7 +355,7 @@ const clearDraft = () => {
   .player-name {
     grid-area: name;
     font-weight: 600;
-    font-size: clamp(0.55rem, 2.2vw, 2rem);
+    font-size: clamp(0.5rem, 1.5vw, 1.4rem);
     text-align: center;
     line-height: 1.15;
     align-self: center;

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -96,21 +96,22 @@ const undoClear = (which: 'keepers' | 'draft') => {
       {/each}
     </div>
     <div class="header-right">
-      <div class="legend-text">
-        <span><strong>Arrows:</strong> Show disagreement</span>
-        <span>•</span>
-        <span>Longer = more variance</span>
-      </div>
-      <nav aria-label="Data actions">
-        <button
-          disabled={!$keepers.length}
-          onclick={clearKeepers}>Clear Keepers ({$keepers.length || 0})</button
-        >
-        <button
-          disabled={!$draft.length}
-          onclick={clearDraft}>Clear Draft ({$draft.length || 0})</button
-        >
-      </nav>
+      <button class="legend-toggle" title="Arrows show ranking disagreement between sources. Longer arrow = more variance." aria-label="Legend: arrows show ranking disagreement">?</button>
+      {#if $currentTab !== "all players"}
+        <nav aria-label="Data actions">
+          {#if $currentTab === "keepers"}
+            <button
+              disabled={!$keepers.length}
+              onclick={clearKeepers}>Clear ({$keepers.length || 0})</button
+            >
+          {:else if $currentTab === "draft"}
+            <button
+              disabled={!$draft.length}
+              onclick={clearDraft}>Clear ({$draft.length || 0})</button
+            >
+          {/if}
+        </nav>
+      {/if}
     </div>
   </header>
   <main>
@@ -131,27 +132,19 @@ const undoClear = (which: 'keepers' | 'draft') => {
               findPlayer(player, $draft) !== undefined}
             title="{player.name} - Variance: {player.variance || 0}{player.rankings ? ` | FF: ${player.rankings.ff || 'N/A'} | ESPN: ${player.rankings.espn || 'N/A'} | FP: ${player.rankings.fp || 'N/A'}` : ''}"
           >
-            <div class="player-top">
-              <div class="player-meta">
-                <p class="player-rank">
-                  #{player.rank}
-                </p>
-                <p class="player-position">{player.position.position}</p>
-              </div>
-            </div>
-            <div class="player-center">
-              <p class="player-name">{player.name}</p>
-            </div>
-            <div class="player-bottom">
-              <p>{player.team}</p>
-              <div class="compass-container">
-                <RankingArrow 
-                  vector={player.vector} 
-                  consensusStrength={player.consensusStrength}
-                  size={32}
-                />
-              </div>
-            </div>
+            <span class="player-meta">
+              <span class="player-rank">#{player.rank}</span>
+              <span class="player-pos">{player.position.position}</span>
+              <span class="player-team">{player.team}</span>
+            </span>
+            <span class="player-name">{player.name}</span>
+            <span class="compass-container">
+              <RankingArrow 
+                vector={player.vector} 
+                consensusStrength={player.consensusStrength}
+                size={22}
+              />
+            </span>
           </button>
         {/each}
       {/each}
@@ -180,11 +173,7 @@ const undoClear = (which: 'keepers' | 'draft') => {
         {/if}
         {#if $currentTab === "draft"}
           <div class="tab-header">
-            <h2>Draft</h2>
-            <div>
-              <p>Round: {currentRound($draft)}</p>
-              <p>Pick: {currentPick($draft)}</p>
-            </div>
+            <h2>Draft <span class="draft-info">R{currentRound($draft)} · P{currentPick($draft)}</span></h2>
           </div>
 
           <div class="draft">
@@ -211,6 +200,7 @@ const undoClear = (which: 'keepers' | 'draft') => {
 {/await}
 
 <style>
+  /* ---- reset ---- */
   button:disabled {
     opacity: 0.5;
     cursor: not-allowed;
@@ -221,268 +211,395 @@ const undoClear = (which: 'keepers' | 'draft') => {
     margin: 0;
   }
 
-  main {
-    display: flex;
-    justify-content: space-between;
-  }
-
-  aside {
-    border-left: 2px solid #444;
-    padding: 1rem;
-    width: 20%;
-    background: rgba(2, 2, 2, 0.9);
-    backdrop-filter: blur(0.5px);
-  }
-
-  aside h2 {
-    font-size: 1.5rem;
-    font-weight: 500;
-    margin-bottom: 1rem;
-    border-bottom: 2px solid #444;
-    display: flex;
-    justify-content: space-between;
-  }
-
-  .player-keeper {
-    filter: grayscale(1) brightness(0.6);
-  }
-  .player-keeper::before {
-    content: "Keeper";
-    background: rgba(255, 255, 255, 0.6);
-    color: #000;
-    padding: 0;
-    font-size: 0.5rem;
-    width: 100%;
-    text-transform: uppercase;
-  }
-  aside .draft {
-    display: grid;
-
-    width: 100%;
-  }
-
-  aside .draft-player {
-    padding: 0.1rem;
-    border: 1px solid #444;
-    display: flex;
-    align-items: center;
-    gap: 0.2rem;
-  }
-
-  aside .draft-player .name {
-    font-weight: 500;
-    text-align: center;
-    font-size: 0.8rem;
-    line-height: 1;
-    flex: 1;
-  }
-
-  aside .draft-player .rank {
-    font-size: 0.7rem;
-    font-weight: 500;
-  }
-
-  aside .draft-player .compass-small {
-    display: flex;
-    align-items: center;
-  }
-
-  .empty-hint {
-    color: #888;
-    font-size: 0.8rem;
-    font-style: italic;
-    padding: 0.5rem 0;
-  }
-
-  @media (max-width: 1092px) {
-    main {
-      flex-direction: column;
-    }
-
-    aside {
-      border-left: 0;
-      border-top: 2px solid #444;
-      padding-top: 1rem;
-      width: calc(100% - 2rem);
-      position: sticky;
-      bottom: 0;
-      max-height: 20vh;
-      overflow-y: auto;
-    }
-    aside .draft {
-      grid-auto-flow: column;
-      grid-template-rows: repeat(8, minmax(0, 1fr));
-    }
-  }
-
-  .grid {
-    margin: 1rem;
-    display: grid;
-    grid-template-columns: repeat(12, 1fr);
-    gap: 1px;
-    place-items: center;
-  }
-
-  .player {
-    border-radius: 4px;
-    color: #fff;
-    height: 90px;
-    width: 90px;
-    appearance: none;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    border: 1px solid #222;
-    margin: 0px;
-    cursor: pointer;
-    background: transparent;
-    position: relative;
-  }
-  .player-selected {
-    filter: grayscale(0.5) brightness(0.6);
-  }
-
-  .player-top {
-    height: 16px;
-    padding: 4px 4px 0 4px;
-  }
-  
-  .player-center {
-    flex: 1;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0 4px;
-  }
-
-  .player-name {
-    font-weight: 500;
-    font-size: 0.85rem;
-    text-align: center;
-    word-break: break-word;
-    hyphens: auto;
-    margin: 0;
-    line-height: 1.1;
-  }
-
-  .player-meta {
-    width: 100%;
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    font-size: 0.7rem;
-    line-height: 1;
-  }
-  
-  .player-meta p {
-    margin: 0;
-    font-weight: 600;
-  }
-
-  .player-bottom {
-    height: 20px;
-    display: flex;
-    align-items: flex-end;
-    padding: 0 4px 4px 4px;
-  }
-  
-  .player-bottom > p {
-    font-size: 0.75rem;
-    font-weight: 400;
-    margin: 0;
-    line-height: 1;
-  }
-
-  .compass-container {
-    position: absolute;
-    right: -8px;
-    bottom: -8px;
-    width: 32px;
-    height: 32px;
-    pointer-events: none;
-    z-index: 1;
-  }
-
+  /* ---- header ---- */
   header {
     display: flex;
     align-items: flex-end;
     justify-content: space-between;
     border-bottom: 2px solid #444;
-    margin-top: 1rem;
+    padding: 0.25rem 0;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    background: #242424;
     flex-wrap: nowrap;
   }
-  
-  .header-right {
+
+  [role="tablist"] {
     display: flex;
-    align-items: center;
-    gap: 1rem;
   }
-  
-  .legend-text {
-    display: flex;
-    gap: 0.5rem;
-    font-size: 0.75rem;
+
+  [role="tablist"] button {
+    border: 0;
+    background: transparent;
     color: #aaa;
-    align-items: center;
-    padding: 0 1rem;
-    border-left: 1px solid #444;
+    padding: 0.35rem 0.75rem;
+    font-size: 0.8rem;
+    cursor: pointer;
+    font-weight: 500;
+    text-transform: lowercase;
+    transition: color 0.15s, background 0.15s;
+    border-radius: 3px 3px 0 0;
   }
-  
-  .legend-text strong {
+
+  [role="tablist"] button:hover {
     color: #fff;
   }
 
+  [role="tablist"] button.selected {
+    background: #444;
+    color: #fff;
+  }
+
+  .header-right {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .legend-toggle {
+    background: none;
+    border: 1px solid #555;
+    color: #aaa;
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    font-size: 0.7rem;
+    font-weight: 700;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    transition: color 0.15s, border-color 0.15s;
+  }
+
+  .legend-toggle:hover {
+    color: #fff;
+    border-color: #888;
+  }
+
   nav {
-    margin-left: 1rem;
-    margin-right: 1rem;
     display: flex;
   }
 
   nav button {
     border: 0;
-    font-size: large;
+    font-size: 0.75rem;
     background: transparent;
     border-top: 2px solid #444;
     border-left: 2px solid #444;
-    padding: 0.5rem 1rem;
+    padding: 0.35rem 0.6rem;
     cursor: pointer;
-    color: #fff;
-    text-transform: lowercase;
+    color: #aaa;
+    transition: color 0.15s;
   }
 
   nav button:last-child {
     border-right: 2px solid #444;
   }
 
-  [role="tablist"] button.selected {
-    background: #444;
+  nav button:hover:not(:disabled) {
+    color: #fff;
+  }
+
+  /* ---- main layout ---- */
+  main {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  /* ---- grid ---- */
+  .grid {
+    margin: 0.5rem;
+    display: grid;
+    grid-template-columns: repeat(12, 1fr);
+    gap: 1px;
+    place-items: stretch;
+    flex: 1;
+  }
+
+  /* ---- player card ---- */
+  .player {
+    border-radius: 3px;
+    color: #fff;
+    appearance: none;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    grid-template-rows: auto 1fr;
+    grid-template-areas:
+      "meta compass"
+      "name compass";
+    border: 1px solid rgba(255,255,255,0.08);
+    margin: 0;
+    padding: 2px 4px;
+    cursor: pointer;
+    background: transparent;
+    position: relative;
+    min-height: 56px;
+    transition: filter 0.15s, box-shadow 0.15s;
+  }
+
+  .player:hover {
+    filter: brightness(1.2);
+    z-index: 2;
+    box-shadow: 0 0 0 2px rgba(255,255,255,0.25);
+  }
+
+  .player:focus-visible {
+    outline: 2px solid #fff;
+    outline-offset: 2px;
+    z-index: 3;
+  }
+
+  .player-meta {
+    grid-area: meta;
+    display: flex;
+    gap: 0.3rem;
+    align-items: center;
+    font-size: 0.6rem;
+    font-weight: 600;
+    line-height: 1.2;
+    white-space: nowrap;
+  }
+
+  .player-rank {
+    opacity: 0.75;
+  }
+
+  .player-pos {
+    opacity: 0.85;
+  }
+
+  .player-team {
+    opacity: 0.55;
+    margin-left: auto;
+  }
+
+  .player-name {
+    grid-area: name;
+    font-weight: 500;
+    font-size: 0.75rem;
+    text-align: left;
+    line-height: 1.15;
+    align-self: center;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .compass-container {
+    grid-area: compass;
+    width: 22px;
+    height: 22px;
+    align-self: start;
+    justify-self: end;
+    position: relative;
+    flex-shrink: 0;
+    opacity: 0.8;
+  }
+
+  /* ---- selected states ---- */
+  .player-selected {
+    opacity: 0.55;
+    box-shadow: inset 0 0 0 2px rgba(255,255,255,0.5);
+  }
+
+  .player-keeper {
+    box-shadow: inset 0 0 0 2px rgba(255,255,255,0.7);
+    opacity: 0.5;
+  }
+
+  .player-keeper::after {
+    content: "K";
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    background: rgba(255,255,255,0.85);
+    color: #111;
+    font-size: 0.45rem;
+    font-weight: 700;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1;
+    line-height: 1;
+  }
+
+  .player-drafted {
+    box-shadow: inset 0 0 0 2px rgba(255,255,255,0.5);
+    opacity: 0.5;
+  }
+
+  /* ---- sidebar ---- */
+  aside {
+    border-left: 1px solid #444;
+    padding: 0.75rem;
+    width: min(200px, 18%);
+    background: #1a1a1a;
+    flex-shrink: 0;
+  }
+
+  aside h2 {
+    font-size: 1rem;
+    font-weight: 500;
+    margin-bottom: 0.5rem;
+    border-bottom: 1px solid #444;
+    padding-bottom: 0.35rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+  }
+
+  .draft-info {
+    font-size: 0.65rem;
+    font-weight: 400;
+    color: #888;
+  }
+
+  aside .draft {
+    display: grid;
+    width: 100%;
+  }
+
+  aside .draft-player {
+    padding: 2px 4px;
+    border: 1px solid #333;
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+  }
+
+  aside .draft-player .name {
+    font-weight: 500;
+    text-align: center;
+    font-size: 0.7rem;
+    line-height: 1.2;
+    flex: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  aside .draft-player .rank {
+    font-size: 0.6rem;
+    font-weight: 500;
+    color: #888;
+  }
+
+  aside .draft-player .compass-small {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+  }
+
+  .empty-hint {
+    color: #666;
+    font-size: 0.7rem;
+    font-style: italic;
+    padding: 0.35rem 0;
+  }
+
+  /* ---- responsive ---- */
+  @media (max-width: 800px) {
+    .player {
+      min-height: 44px;
+      padding: 1px 3px;
+    }
+
+    .player-name {
+      font-size: 0.6rem;
+    }
+
+    .player-meta {
+      font-size: 0.5rem;
+      gap: 0.15rem;
+    }
+
+    .compass-container {
+      width: 16px;
+      height: 16px;
+    }
+
+    [role="tablist"] button {
+      padding: 0.25rem 0.5rem;
+      font-size: 0.7rem;
+    }
   }
 
   @media (max-width: 1091px) {
-    header nav button {
-      font-size: small;
-      padding: 0.5rem 0.5rem;
+    main {
+      flex-direction: column;
     }
-    .player {
-      height: 60px;
-      width: 60px;
-      padding: 2px;
+
+    aside {
+      border-left: 0;
+      border-top: 1px solid #444;
+      padding: 0.5rem 0.75rem;
+      width: calc(100% - 1.5rem);
+      position: sticky;
+      bottom: 0;
+      max-height: 15vh;
+      overflow-y: auto;
+      background: #1a1a1a;
     }
-    .player-name {
+
+    aside h2 {
+      font-size: 0.85rem;
+      margin-bottom: 0.25rem;
+      padding-bottom: 0.25rem;
+    }
+
+    aside .draft {
+      grid-auto-flow: column;
+      grid-template-rows: repeat(6, minmax(0, 1fr));
+    }
+
+    aside .draft-player .name {
+      font-size: 0.6rem;
+    }
+
+    nav button {
       font-size: 0.65rem;
+      padding: 0.3rem 0.5rem;
     }
+  }
+
+  @media (max-width: 500px) {
+    .player {
+      min-height: 38px;
+      padding: 1px 2px;
+    }
+
+    .player-name {
+      font-size: 0.52rem;
+    }
+
     .player-meta {
-      font-size: 0.5rem;
+      font-size: 0.45rem;
+      gap: 0.1rem;
     }
-    .player-bottom > p {
-      font-size: 0.55rem;
-    }
-    .player-bottom {
-      height: 20px;
-    }
+
     .compass-container {
-      right: -2px;
-      bottom: -2px;
+      width: 12px;
+      height: 12px;
+    }
+
+    .grid {
+      margin: 0.25rem;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .player,
+    .player:hover,
+    nav button,
+    [role="tablist"] button,
+    .legend-toggle {
+      transition: none;
     }
   }
 </style>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -145,13 +145,6 @@ const undoClear = (which: 'keepers' | 'draft') => {
                 <span>FP {player.rankings.fp ?? '—'}</span>
               {/if}
             </span>
-            <span class="compass-container">
-              <RankingArrow 
-                vector={player.vector} 
-                consensusStrength={player.consensusStrength}
-                size={30}
-              />
-            </span>
           </button>
         {/each}
       {/each}
@@ -321,6 +314,7 @@ const undoClear = (which: 'keepers' | 'draft') => {
     gap: 2px;
     place-items: stretch;
     flex: 1;
+    max-width: 1100px;
   }
 
   /* ---- player card ---- */
@@ -329,12 +323,11 @@ const undoClear = (which: 'keepers' | 'draft') => {
     color: #fff;
     appearance: none;
     display: grid;
-    grid-template-columns: 1fr auto;
     grid-template-rows: auto 1fr auto;
     grid-template-areas:
-      "meta compass"
-      "name compass"
-      "ranks compass";
+      "meta"
+      "name"
+      "ranks";
     border: 1px solid rgba(255,255,255,0.08);
     margin: 0;
     padding: 3px 5px;
@@ -389,7 +382,7 @@ const undoClear = (which: 'keepers' | 'draft') => {
   .player-name {
     grid-area: name;
     font-weight: 600;
-    font-size: 0.85rem;
+    font-size: clamp(0.55rem, 3vw, 0.85rem);
     text-align: center;
     line-height: 1.15;
     align-self: center;
@@ -414,17 +407,6 @@ const undoClear = (which: 'keepers' | 'draft') => {
 
   .player-ranks span {
     white-space: nowrap;
-  }
-
-  .compass-container {
-    grid-area: compass;
-    width: 30px;
-    height: 30px;
-    align-self: start;
-    justify-self: end;
-    position: relative;
-    flex-shrink: 0;
-    opacity: 0.8;
   }
 
   /* ---- selected states ---- */
@@ -542,10 +524,6 @@ const undoClear = (which: 'keepers' | 'draft') => {
       padding: 1px 3px;
     }
 
-    .player-name {
-      font-size: 0.65rem;
-    }
-
     .player-meta {
       font-size: 0.5rem;
       gap: 0.15rem;
@@ -553,11 +531,6 @@ const undoClear = (which: 'keepers' | 'draft') => {
 
     .player-ranks {
       font-size: 0.44rem;
-    }
-
-    .compass-container {
-      width: 20px;
-      height: 20px;
     }
 
     [role="tablist"] button {
@@ -609,10 +582,6 @@ const undoClear = (which: 'keepers' | 'draft') => {
       padding: 1px 2px;
     }
 
-    .player-name {
-      font-size: 0.55rem;
-    }
-
     .player-meta {
       font-size: 0.45rem;
       gap: 0.1rem;
@@ -620,11 +589,6 @@ const undoClear = (which: 'keepers' | 'draft') => {
 
     .player-ranks {
       font-size: 0.38rem;
-    }
-
-    .compass-container {
-      width: 14px;
-      height: 14px;
     }
 
     .grid {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -314,7 +314,6 @@ const undoClear = (which: 'keepers' | 'draft') => {
     gap: 2px;
     place-items: stretch;
     flex: 1;
-    max-width: 1100px;
   }
 
   /* ---- player card ---- */
@@ -335,6 +334,7 @@ const undoClear = (which: 'keepers' | 'draft') => {
     background: transparent;
     position: relative;
     aspect-ratio: 1;
+    max-width: 72px;
     transition: filter 0.15s, box-shadow 0.15s;
     font-family: 'Barlow Condensed', 'Inter', system-ui, sans-serif;
   }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -113,7 +113,7 @@ const clearDraft = () => {
               <span class="player-pos">{player.position.position}</span>
               <span class="player-team">{player.team}</span>
             </span>
-            <span class="player-name" style="--name-scale: {player.name.length > 15 ? 0.72 : player.name.length > 12 ? 0.85 : 1}">{player.name}</span>
+            <span class="player-name" style="--name-scale: {Math.max(0.82, 1 - (player.name.length - 12) * 0.018)}">{player.name}</span>
             <span class="player-ranks">
               {#if player.rankings}
                 <span>FF {player.rankings.ff ?? '—'}</span>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -355,7 +355,7 @@ const clearDraft = () => {
   .player-name {
     grid-area: name;
     font-weight: 600;
-    font-size: clamp(0.5rem, 1.5vw, 1.4rem);
+    font-size: clamp(0.5rem, 1.2vw, 0.9rem);
     text-align: center;
     line-height: 1.15;
     align-self: center;
@@ -540,6 +540,12 @@ const clearDraft = () => {
   @media (max-width: 500px) {
     .grid {
       margin: 0.25rem;
+    }
+  }
+
+  @media (min-width: 1100px) {
+    .player-name {
+      font-size: clamp(0.9rem, 2vw, 1.8rem);
     }
   }
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -333,7 +333,7 @@ const undoClear = (which: 'keepers' | 'draft') => {
     cursor: pointer;
     background: transparent;
     position: relative;
-    min-height: 56px;
+    aspect-ratio: 1;
     transition: filter 0.15s, box-shadow 0.15s;
   }
 
@@ -438,6 +438,8 @@ const undoClear = (which: 'keepers' | 'draft') => {
     width: min(200px, 18%);
     background: #1a1a1a;
     flex-shrink: 0;
+    overflow-x: hidden;
+    overflow-y: auto;
   }
 
   aside h2 {
@@ -476,6 +478,7 @@ const undoClear = (which: 'keepers' | 'draft') => {
     font-size: 0.7rem;
     line-height: 1.2;
     flex: 1;
+    min-width: 0;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -503,7 +506,6 @@ const undoClear = (which: 'keepers' | 'draft') => {
   /* ---- responsive ---- */
   @media (max-width: 800px) {
     .player {
-      min-height: 44px;
       padding: 1px 3px;
     }
 
@@ -567,7 +569,6 @@ const undoClear = (which: 'keepers' | 'draft') => {
 
   @media (max-width: 500px) {
     .player {
-      min-height: 38px;
       padding: 1px 2px;
     }
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -329,7 +329,7 @@ const undoClear = (which: 'keepers' | 'draft') => {
       "ranks";
     border: 1px solid rgba(255,255,255,0.08);
     margin: 0;
-    padding: 3px 5px;
+    padding: clamp(1px, 0.3vw, 4px) clamp(2px, 0.5vw, 5px);
     cursor: pointer;
     background: transparent;
     position: relative;
@@ -357,9 +357,9 @@ const undoClear = (which: 'keepers' | 'draft') => {
   .player-meta {
     grid-area: meta;
     display: flex;
-    gap: 0.3rem;
+    gap: clamp(0.1rem, 0.5vw, 0.3rem);
     align-items: center;
-    font-size: 0.65rem;
+    font-size: clamp(0.45rem, 1.8vw, 0.65rem);
     font-weight: 600;
     line-height: 1.2;
     white-space: nowrap;
@@ -397,7 +397,7 @@ const undoClear = (which: 'keepers' | 'draft') => {
     grid-area: ranks;
     display: flex;
     justify-content: space-around;
-    font-size: 0.52rem;
+    font-size: clamp(0.35rem, 1.4vw, 0.52rem);
     font-weight: 400;
     opacity: 0.6;
     line-height: 1;
@@ -519,19 +519,6 @@ const undoClear = (which: 'keepers' | 'draft') => {
 
   /* ---- responsive ---- */
   @media (max-width: 800px) {
-    .player {
-      padding: 1px 3px;
-    }
-
-    .player-meta {
-      font-size: 0.5rem;
-      gap: 0.15rem;
-    }
-
-    .player-ranks {
-      font-size: 0.44rem;
-    }
-
     [role="tablist"] button {
       padding: 0.25rem 0.5rem;
       font-size: 0.7rem;
@@ -577,19 +564,6 @@ const undoClear = (which: 'keepers' | 'draft') => {
   }
 
   @media (max-width: 500px) {
-    .player {
-      padding: 1px 2px;
-    }
-
-    .player-meta {
-      font-size: 0.45rem;
-      gap: 0.1rem;
-    }
-
-    .player-ranks {
-      font-size: 0.38rem;
-    }
-
     .grid {
       margin: 0.25rem;
     }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -113,7 +113,7 @@ const clearDraft = () => {
               <span class="player-pos">{player.position.position}</span>
               <span class="player-team">{player.team}</span>
             </span>
-            <span class="player-name" style="--name-scale: {Math.max(0.82, 1 - (Math.max(...player.name.split(' ').map(w => w.length)) - 7) * 0.035)}">{player.name}</span>
+            <span class="player-name" style="--name-scale: {Math.max(0.78, 1 - (Math.max(...player.name.split(' ').map(w => w.length)) - 7) * 0.045)}">{player.name}</span>
             <span class="player-ranks">
               {#if player.rankings}
                 <span>FF {player.rankings.ff ?? '—'}</span>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -308,6 +308,7 @@ const clearDraft = () => {
     background: transparent;
     position: relative;
     aspect-ratio: 1;
+    overflow: hidden;
     transition: filter 0.15s, box-shadow 0.15s;
     font-family: 'Barlow Condensed', 'Inter', system-ui, sans-serif;
   }
@@ -355,14 +356,10 @@ const clearDraft = () => {
   .player-name {
     grid-area: name;
     font-weight: 600;
-    font-size: clamp(0.48rem, 1.1vw, 0.85rem);
+    font-size: clamp(0.48rem, 1vw, 0.8rem);
     text-align: center;
     line-height: 1.15;
     align-self: center;
-    overflow: hidden;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
     letter-spacing: 0.01em;
     word-break: break-word;
   }
@@ -465,10 +462,6 @@ const clearDraft = () => {
     line-height: 1.2;
     flex: 1;
     min-width: 0;
-    overflow: hidden;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
     word-break: break-word;
   }
 
@@ -545,7 +538,7 @@ const clearDraft = () => {
 
   @media (min-width: 1100px) {
     .player-name {
-      font-size: clamp(0.85rem, 1.9vw, 1.35rem);
+      font-size: clamp(0.8rem, 1.6vw, 1.2rem);
     }
   }
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -545,7 +545,7 @@ const clearDraft = () => {
 
   @media (min-width: 1100px) {
     .player-name {
-      font-size: clamp(0.9rem, 2vw, 1.8rem);
+      font-size: clamp(0.9rem, 2vw, 1.4rem);
     }
   }
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -490,13 +490,6 @@ const clearDraft = () => {
   }
 
   /* ---- responsive ---- */
-  @media (max-width: 800px) {
-    [role="tablist"] button {
-      padding: 0.25rem 0.5rem;
-      font-size: 0.7rem;
-    }
-  }
-
   @media (max-width: 1091px) {
     main {
       flex-direction: column;
@@ -535,7 +528,7 @@ const clearDraft = () => {
     }
   }
 
-  @media (max-width: 500px) {
+  @media (max-width: 768px) {
     .grid {
       margin: 0.25rem;
     }
@@ -555,6 +548,11 @@ const clearDraft = () => {
       grid-template-areas:
         "meta"
         "name";
+    }
+
+    [role="tablist"] button {
+      padding: 0.25rem 0.5rem;
+      font-size: 0.7rem;
     }
   }
 


### PR DESCRIPTION
## Summary

Makes the fantasy draft grid more compact without sacrificing readability or minimalism.

### Player Cards
- Reshaped from rigid **90×90px squares** to fluid **landscape cards** (min-height 56px, fill grid column width)
- Flattened 3-section flex layout into a **CSS grid** with meta-line (rank · position · team) + name + compass all inline
- Compass arrow now **contained within card bounds** (22px, was 32px bleeding out at -8px)
- Name truncates with ellipsis — more horizontal room than old squares

### Header
- **Sticky** — stays visible while scrolling 300 players
- Legend collapsed into a compact **? tooltip button**
- Clear buttons only appear on their **relevant tab** (keepers tab → clear keepers, etc.)

### Sidebar
- Width reduced from 20% to **min(200px, 18%)**
- Background simplified (no more backdrop-filter)
- Draft Round/Pick merged: **R3 · P5**

### Interactions
- Hover: brightness + white ring with 150ms transition
- Selection: opacity + inset border — **preserves position colors** (was destructive grayscale)
- Keeper badge: small **K circle** in corner via ::after (was full-width ::before overlay)
- Visible **focus-visible** outlines for keyboard navigation
- **prefers-reduced-motion** respected

### Responsive
- Three breakpoints: **800px / 1091px / 500px** with smooth scaling
- Sidebar collapses below grid at 1091px